### PR TITLE
Forecast site and function update 

### DIFF
--- a/0_config.R
+++ b/0_config.R
@@ -1,9 +1,9 @@
 # sourcing functions
-# source("0_config/src/")
+source("0_config/src/metadata_utils.R")
 
 # see https://github.com/eco4cast/neon4cast-example for example forecast 
 # and how to run in github actions 
- 
+
 # target list
 p0_targets_list = list(
   
@@ -49,13 +49,16 @@ p0_targets_list = list(
   # sites we're forecasting at 
   tar_target(
     p0_forecast_site_ids,
-    c("COMO", "MCDI", "POSE")
+    c("BLWA", "FLNT", "TOMB")
   ),
   
   tar_target(
     p0_site_metadata,
-    read_csv("https://raw.githubusercontent.com/eco4cast/neon4cast-aquatics/master/Aquatic_NEON_Field_Site_Metadata_20210928.csv") %>% 
-      filter(field_site_id %in% p0_forecast_site_ids) 
+    read_csv("https://raw.githubusercontent.com/eco4cast/neon4cast-targets/main/NEON_Field_Site_Metadata_20220412.csv") %>% 
+      filter(field_site_id %in% p0_forecast_site_ids) %>% 
+      rowwise() %>% 
+      mutate(COMID = comid_from_point(field_latitude, field_longitude),
+             tz = get_tz(field_latitude, field_longitude)) %>% 
+      ungroup() 
   )
-  
 )

--- a/0_config/src/metadata_utils.R
+++ b/0_config/src/metadata_utils.R
@@ -1,0 +1,39 @@
+
+#' Define a function to return the corresponding comid
+#' author: Phil Savoy, Jake Zwart 
+#' 
+comid_from_point <- function(lat, lon, CRS = 4326) {
+  point <- sf::st_sfc(sf::st_point(c(lon, lat)), crs = CRS)
+  COMID <- nhdplusTools::discover_nhdplus_id(point)
+  if(! length(COMID)) COMID = NA
+  return(COMID)
+}
+
+
+get_tz <- function(lat, lon){
+   
+  #Import the tz_world dataset if it is not already loaded
+  if(!exists("tz_world")){data("tz_world", package = "StreamLightUtils")}
+  data <- tibble(lat = lat, lon = lon) 
+  #Project (These sites all are in WGS84)
+  sites_WGS84 <- sf::st_as_sf(
+    data, 
+    coords = c("lon", "lat"),
+    crs = 4326
+  )    
+  
+  #Return the timezone name
+  tz_join <- sf::st_join(
+    sites_WGS84, 
+    tz_world,
+    join = sf::st_nearest_feature
+  )
+  
+  #Drop geometry
+  drop <- sf::st_drop_geometry(tz_join)
+  
+  #Remove the factor
+  tz_name <- as.character(drop$TZID)
+  
+  return(tz_name) 
+}

--- a/1_data.R
+++ b/1_data.R
@@ -1,5 +1,6 @@
 # sourcing functions
 source("1_data/src/summarize_drivers.R")
+source("1_data/src/nwm_utils.R")
 
 # packages needed for these targets
 tar_option_set(packages = c(
@@ -15,7 +16,7 @@ p1_targets_list = list(
   tar_target(
     # issue date of the forecast; setting to system time 
     p1_forecast_issue_date, 
-    "2022-06-21",
+    as.Date("2022-08-01"),
     # Sys.Date(),
     cue = tar_cue(mode = "always")
   ),
@@ -23,15 +24,15 @@ p1_targets_list = list(
   # all targets (i.e. observations) for the forecast sties 
   tar_target(
     p1_aquatic_targets,
-    aquatic <- read_csv("https://data.ecoforecast.org/targets/aquatics/aquatics-targets.csv.gz") %>% 
-      dplyr::filter(siteID %in% p0_forecast_site_ids) %>% 
-      as_tsibble(index = time, key = siteID),
+    aquatic <- read_csv("https://data.ecoforecast.org/neon4cast-targets/aquatics/aquatics-targets.csv.gz") %>% 
+      dplyr::filter(site_id %in% p0_forecast_site_ids) %>% 
+      as_tsibble(index = time, key = c(site_id,variable)),
     cue = tar_cue(mode = "always")
   ),
   
   tar_target(
     # drivers for training models 
-    p1_historic_drivers_noaa_gefs_nc,
+    p1_historic_drivers_noaa_gefs_rds,
     # # install.packages("remotes")
     # remotes::install_github("cboettig/aws.s3") 
     # remotes::install_github("eco4cast/neon4cast")
@@ -44,100 +45,51 @@ p1_targets_list = list(
     # Sys.setenv("AWS_S3_ENDPOINT"="ecoforecast.org")
     # 
     # neon4cast::get_stacked_noaa_s3(".",site = "POSE", averaged = FALSE, s3_region="data")
+    # neon4cast::noaa_stage1()
     {
       p1_forecast_issue_date
       Sys.setenv("AWS_DEFAULT_REGION" = "data",
                  "AWS_S3_ENDPOINT" = "ecoforecast.org")
       
-      neon4cast::get_stacked_noaa_s3("1_data/in", 
-                                     site = p0_forecast_site_ids, 
-                                     averaged = FALSE,
-                                     s3_region="data")
-      return(p1_forecast_issue_date) 
-    },
-    # 8 variables (excluding dimension variables):
-    # float air_temperature[time,latitude,longitude]   
-    # units: K
-    # _FillValue: NaN
-    # float air_pressure[time,latitude,longitude]   
-    # units: Pa
-    # _FillValue: NaN
-    # float relative_humidity[time,latitude,longitude]   
-    # units: 1
-    # _FillValue: NaN
-    # float surface_downwelling_longwave_flux_in_air[time,latitude,longitude]   
-    # units: Wm-2
-    # _FillValue: NaN
-    # float surface_downwelling_shortwave_flux_in_air[time,latitude,longitude]   
-    # units: Wm-2
-    # _FillValue: NaN
-    # float precipitation_flux[time,latitude,longitude]   
-    # units: kgm-2s-1
-    # _FillValue: NaN
-    # float specific_humidity[time,latitude,longitude]   
-    # units: 1
-    # _FillValue: NaN
-    # float wind_speed[time,latitude,longitude]   
-    # units: ms-1
-    # _FillValue: NaN
-    # 3 dimensions:
-    # time  Size:14568 
-    # units: hours since 2020-09-25 00:00
-    # long_name: time
-    # latitude  Size:1 
-    # units: degree_north
-    # long_name: latitude
-    # longitude  Size:1 
-    # units: degree_east
-    # long_name: longitude
-    pattern = map(p0_forecast_site_ids)
-  ),
-  
-  tar_target(
-    # stack together historic drivers 
-    p1_historic_drivers_noaa_gefs_rds,
-    {
       out_file = "1_data/out/historic_gefs.rds"
-      p1_historic_drivers_noaa_gefs_nc
-      saveRDS(neon4cast::stack_noaa(dir = "1_data/in/drivers",
-                                    model = "NOAAGEFS_1hr_stacked"), 
-              file = out_file)
-      return(out_file)
+      
+      # connect to db 
+      historic_gefs <- neon4cast::noaa_stage3()
+      
+      # filter to sites we want and then pull down to local tibble 
+      historic_gefs %>% 
+        dplyr::filter(site_id %in% p0_forecast_site_ids) %>% 
+        dplyr::collect() %>% 
+        saveRDS(file = out_file) 
+      
+      return(out_file) 
     }
   ),
 
   
   tar_target(
     # get forecasted drivers for today's forecast issue date 
-    p1_forecasted_drivers_nc,
+    p1_forecasted_drivers_rds,
     {
       Sys.setenv("AWS_DEFAULT_REGION" = "data",
                  "AWS_S3_ENDPOINT" = "ecoforecast.org")
+
+      out_file = "1_data/out/forecasted_gefs.rds"
       
-      neon4cast::get_noaa_forecast_s3(dir = "1_data/in", 
-                                      model = "NOAAGEFS_1hr",
-                                      site = p0_forecast_site_ids, 
-                                      date = p1_forecast_issue_date, 
-                                      cycle = "00")
-      return(p1_forecast_issue_date)
+      # connect to db 
+      forecasted_gefs <- neon4cast::noaa_stage2()
+      
+      # filter to sites we want and then pull down to local tibble 
+      forecasted_gefs %>% 
+        dplyr::filter(site_id %in% p0_forecast_site_ids,
+                      start_date == as.character(p1_forecast_issue_date)) %>% 
+        dplyr::collect() %>% 
+        saveRDS(file = out_file) 
+      
+      return(out_file) 
     },
-    pattern = map(p0_forecast_site_ids),
     cue = tar_cue(mode = "always")
   ), 
-  
-  tar_target(
-    # stack together forecasted drivers 
-    p1_forecasted_drivers_rds,
-    {
-      out_file = "1_data/out/forecasted_gefs.rds"
-      p1_forecasted_drivers_nc
-      saveRDS(neon4cast::stack_noaa(dir = "1_data/in/drivers",
-                                    model = "NOAAGEFS_1hr", 
-                                    forecast_date = p1_forecast_issue_date),
-              file = out_file)
-      return(out_file) 
-    }
-  ),
   
   tar_target(
     p1_met_drivers,
@@ -169,5 +121,13 @@ p1_targets_list = list(
                       out_file = "1_data/out/forecasted_gefs_daily.rds"),
     cue = tar_cue(mode = "always")
   )
+  
+  # tar_target(
+  #   p1_historic_nwm_rds, 
+  #   download_nwm(sites = p0_site_metadata,
+  #                start_date = "2018-01-01",
+  #                end_date = p1_forecast_issue_date,
+  #                out_file = "1_data/out/historic_nwm.rds") 
+  # )
   
 )

--- a/1_data.R
+++ b/1_data.R
@@ -15,7 +15,9 @@ p1_targets_list = list(
   tar_target(
     # issue date of the forecast; setting to system time 
     p1_forecast_issue_date, 
-    Sys.Date() 
+    "2022-06-21",
+    # Sys.Date(),
+    cue = tar_cue(mode = "always")
   ),
   
   # all targets (i.e. observations) for the forecast sties 
@@ -43,6 +45,7 @@ p1_targets_list = list(
     # 
     # neon4cast::get_stacked_noaa_s3(".",site = "POSE", averaged = FALSE, s3_region="data")
     {
+      p1_forecast_issue_date
       Sys.setenv("AWS_DEFAULT_REGION" = "data",
                  "AWS_S3_ENDPOINT" = "ecoforecast.org")
       
@@ -50,6 +53,7 @@ p1_targets_list = list(
                                      site = p0_forecast_site_ids, 
                                      averaged = FALSE,
                                      s3_region="data")
+      return(p1_forecast_issue_date) 
     },
     # 8 variables (excluding dimension variables):
     # float air_temperature[time,latitude,longitude]   
@@ -115,8 +119,10 @@ p1_targets_list = list(
                                       site = p0_forecast_site_ids, 
                                       date = p1_forecast_issue_date, 
                                       cycle = "00")
+      return(p1_forecast_issue_date)
     },
-    pattern = map(p0_forecast_site_ids)
+    pattern = map(p0_forecast_site_ids),
+    cue = tar_cue(mode = "always")
   ), 
   
   tar_target(
@@ -152,14 +158,16 @@ p1_targets_list = list(
     summarize_drivers(in_file = p1_historic_drivers_noaa_gefs_rds,
                       vars = p1_met_drivers, 
                       group_by_ens = TRUE, 
-                      out_file = "1_data/out/historic_gefs_daily.rds")
+                      out_file = "1_data/out/historic_gefs_daily.rds"),
+    cue = tar_cue(mode = "always")
   ),
   tar_target(
     p1_forecasted_gefs_daily_rds,
     summarize_drivers(in_file = p1_forecasted_drivers_rds,
                       vars = p1_met_drivers, 
                       group_by_ens = TRUE, 
-                      out_file = "1_data/out/forecasted_gefs_daily.rds")
+                      out_file = "1_data/out/forecasted_gefs_daily.rds"),
+    cue = tar_cue(mode = "always")
   )
   
 )

--- a/1_data/src/neon_forecasting_nwm_download.R
+++ b/1_data/src/neon_forecasting_nwm_download.R
@@ -1,0 +1,178 @@
+#================================================================
+#Download and process national water model data for NEON forecasting challenge sites
+#Created 6/7/2022
+#================================================================
+library("dplyr")
+
+# #Requires the StreamLightUtils package (https://github.com/psavoy/StreamLightUtils)
+# #Use the devtools packge to install StreamLightUtils
+#   install.packages("devtools")
+#   devtools::install_github("psavoy/StreamLightUtils")
+
+#-------------------------------------------------
+#Pull in NEON data and get site information for the three streams in the challenge
+#-------------------------------------------------
+  #Get NEON site information (this is the current link as of 6/7/2022 but may change...)
+    neon_info <- readr::read_csv(
+      "https://www.neonscience.org/sites/default/files/NEON_Field_Site_Metadata_20220412.csv"
+    ) %>%
+      as.data.frame()
+  
+  #Read in NEON data from the forecasting challenge
+    neon_data <- readr::read_csv(
+      "https://data.ecoforecast.org/targets/aquatics/aquatics-targets.csv.gz"
+    ) %>%
+      as.data.frame()
+    
+  #Subset the neon site info for only streams and rivers  
+    streams_rivers <- neon_info %>%
+      filter(field_site_subtype %in% c("Wadeable Stream", "Non-wadeable River")) 
+
+  #Find site ids for stream and river sites in the challenge
+    challenge_ids <- intersect(
+      unique(neon_data[, "siteID"]),
+      streams_rivers[, "field_site_id"]
+    )  
+      
+  #Get subset of site information for just the stream challenge sites
+    challenge_sites <- neon_info %>%
+      filter(field_site_id %in% challenge_ids)
+    
+#-------------------------------------------------
+#Add reach comids
+#-------------------------------------------------
+  #Define a function to return the corresponding comid
+    comid_from_point <- function(lat, lon, CRS) {
+      point <- sf::st_sfc(sf::st_point(c(lon, lat)), crs = CRS)
+      COMID <- nhdplusTools::discover_nhdplus_id(point)
+      if(! length(COMID)) COMID = NA
+      return(COMID)
+    } #End comid_from_point function
+    
+  #Apply the funciton to get comids
+    challenge_sites$comid <- mapply(
+      comid_from_point,
+      lat = challenge_sites[, "field_latitude"],
+      lon = challenge_sites[, "field_longitude"],
+      CRS = 4326
+    )
+    
+#-------------------------------------------------   
+#Get timezone information
+#------------------------------------------------- 
+  #Import the tz_world dataset if it is not already loaded
+    if(!exists("tz_world")){data("tz_world", package = "StreamLightUtils")}
+    
+  #Project (These sites all are in WGS84)
+    sites_WGS84 <- sf::st_as_sf(
+      challenge_sites, 
+      coords = c("field_longitude", "field_latitude"),
+      crs = 4326
+    )    
+        
+  #Return the timezone name
+    tz_join <- sf::st_join(
+      sites_WGS84, 
+      tz_world,
+      join = sf::st_nearest_feature
+    )
+    
+  #Drop geometry
+    drop <- sf::st_drop_geometry(tz_join)
+    
+  #Remove the factor
+    drop$tz_name <- as.character(drop$TZID)
+
+  #Get final columns
+    timezones <- drop[, c("field_site_id", "tz_name")]    
+    
+  #Merge timezone information with the site info
+    timezone_merged <- merge(
+      challenge_sites,
+      timezones,
+      by = "field_site_id"
+    )
+    
+#-------------------------------------------------   
+#Download national water model data using the nwmTools package    
+#-------------------------------------------------   
+  #Define a simple wrapper to download national water model data for each comid
+    nwm_downloader <- function(comid, site_info){
+      #Subset site information
+        info_sub <- site_info[site_info[, "comid"] == comid, ]
+        
+      #Download data. For simplicity, download all data and let readNWMdata handle
+      #conversion to local time.
+        nwm_data <- nwmTools::readNWMdata(
+          comid = info_sub[, "comid"],
+          tz = info_sub[, "tz_name"],
+          version = 2.1
+        )    
+    
+      return(nwm_data)
+        
+    } #end nwm_downloader function
+  
+  #Apply the function to download data
+    nwm_downloaded <- lapply(
+      timezone_merged[, "comid"],
+      FUN = nwm_downloader,
+      site_info = timezone_merged
+    )  
+   
+    names(nwm_downloaded) <- timezone_merged[, "comid"]
+    
+#------------------------------------------------- 
+#Calculate mean daily discharge   
+#------------------------------------------------- 
+  #Define a function to aggregate nwm discharge to daily timesteps
+    format_nwm <- function(ts){
+      #If the timeseries isn't null, aggregate to daily values
+      if(!is.null(ts)){
+        #Catch to remove negative values just in case (I think there are none)
+          ts[ts[, "flow_cms_v2.1"] < 0 & !is.na(ts[, "flow_cms_v2.1"]), "flow_cms_v2.1"] <- NA        
+        
+        #Add date information and calculate daily values
+          ts$date <- as.Date(
+            stringr::str_sub(paste(ts[, "dateTime"]), 1, -10),
+            format = "%Y-%m-%d"
+          )
+
+        #Calculate the daily mean value
+          ts_mean <- aggregate(
+            ts[, "flow_cms_v2.1"] ~ date, 
+            data = ts, 
+            FUN = mean, 
+            na.rm = TRUE, 
+            na.action = NULL
+          )    
+          
+          names(ts_mean)[2] <- "nwm_discharge"
+          
+        #Get the final timeseries to return  
+          final <- ts_mean %>%
+            mutate(comid = unique(ts[, "comid"])) %>%
+            select(comid, date, nwm_discharge)
+
+      } else{
+        final <- NULL
+      } #end if else statement 
+      
+      return(final)
+  
+    } #End format_nwm function    
+    
+  #Apply the function to calculate daily discharge
+    nwm_daily <- lapply(
+      nwm_downloaded, 
+      FUN = format_nwm
+    )
+    
+  #Lazy way to assign the NEON site id to the timeseries in the list
+    names(nwm_daily) <- sapply(
+      names(nwm_daily),
+      FUN = function(x){return(challenge_sites %>% filter(comid == x) %>% pull(field_site_id))}
+    )
+        
+
+  

--- a/1_data/src/nwm_utils.R
+++ b/1_data/src/nwm_utils.R
@@ -1,0 +1,29 @@
+
+#' 
+#' author: Phil Savoy, Jake Zwart 
+#' 
+download_nwm <- function(sites,
+                         start_date = NULL,
+                         end_date = NULL,
+                         out_file){
+  map_df <- sites %>% 
+    mutate(comid = COMID, 
+           startDate = start_date,
+           endDate = end_date,
+           version = 2.1) %>% 
+    select(comid, startDate, endDate, tz, version) 
+  browser() 
+  #Download data. For simplicity, download  and let readNWMdata handle
+  #conversion to local time.
+  nwm_data <- purrr::pmap(map_df, nwmTools::readNWMdata()) %>% unlist() 
+  #   nwmTools::readNWMdata(
+  #   comid = sites$COMID,
+  #   startDate = start_date,
+  #   endDate = end_date, 
+  #   tz = sites$tz,
+  #   version = 2.1
+  # )   
+  
+  return(out_file)
+}
+

--- a/1_data/src/summarize_drivers.R
+++ b/1_data/src/summarize_drivers.R
@@ -15,18 +15,17 @@ summarize_drivers <- function(
       # time offset is about 5 hours  
       mutate(time = time - (5 * 3600),
              time = as_date(time)) %>% 
-      group_by(siteID, time, ensemble) %>% 
-      summarise(across(all_of(vars), ~mean(.x, na.rm = T)), 
-                .groups = "drop") %>% 
-      mutate(ensemble = as.numeric(stringr::str_sub(ensemble, start = 4, end = 6))) 
+      group_by(site_id, time, ensemble, variable) %>% 
+      summarise(predicted = mean(predicted, na.rm = T), 
+                .groups = "drop") 
   }else{
     summarized_data <- data %>% 
       # time offset is about 5 hours  
       mutate(time = time - (5 * 3600),
              time = as_date(time)) %>% 
-      group_by(siteID, time) %>% 
-      summarise(across(all_of(vars), ~mean(.x, na.rm = T)), 
-                .groups = "drop")
+      group_by(site_id, time, variable) %>% 
+      summarise(predicted = mean(predicted, na.rm = T), 
+                .groups = "drop") 
   }
   
   saveRDS(summarized_data, out_file)

--- a/2_model.R
+++ b/2_model.R
@@ -20,6 +20,7 @@ p2_targets_list = list(
     # covariates of the model 
     p2_driver_vars,
     c("air_temperature",
+      "relative_humidity", 
       "surface_downwelling_shortwave_flux_in_air",
       "precipitation_flux")
   ),

--- a/2_model/src/chla_models.R
+++ b/2_model/src/chla_models.R
@@ -8,29 +8,33 @@ train_model <- function(driver_file,
                         site, 
                         out_file){
    
-  target <- filter(target_file, siteID == site) %>% 
-    select(time, siteID, !!target_vars)
+  target <- filter(target_file, 
+                   site_id == site,
+                   variable == target_vars) %>% 
+    pivot_wider(names_from = variable, values_from = observed)
    
   drivers <- readRDS(driver_file) %>% 
-    filter(siteID == site) %>% 
-    select(time, all_of(driver_vars)) %>% 
+    filter(site_id == site,
+           variable %in% driver_vars) %>% 
     # taking mean of ensemble members 
-    group_by(time) %>% 
-    summarise(across(all_of(driver_vars), ~mean(.x, na.rm = T)), 
-              .groups = "drop")
+    group_by(time, variable) %>% 
+    summarise(predicted = mean(predicted, na.rm = T), 
+              .groups = "drop") %>% 
+    pivot_wider(names_from = variable, values_from = predicted) 
   
   all_data <- left_join(target, drivers, by = "time") %>% 
     filter_at(driver_vars, all_vars(!is.na(.))) %>% 
     mutate(chla_lagged_1 = dplyr::lag(chla, n = 1)) %>% 
     slice(2:n()) 
-  
+  browser() 
   model <- lm(chla ~ chla_lagged_1 + 
                 air_temperature + 
+                relative_humidity + 
                 surface_downwelling_shortwave_flux_in_air + 
                 precipitation_flux, 
               data = all_data) 
   summary(model)
-  
+   
   saveRDS(model, out_file) 
   return(out_file) 
 }
@@ -41,14 +45,16 @@ predict_chla <- function(
     trained_model,
     chla_lagged_1,
     air_temp,
+    rh,
     swrad,
     precip)
 {
   chla = trained_model$coefficients[1] + 
     trained_model$coefficients[2]*chla_lagged_1 + 
     trained_model$coefficients[3]*air_temp + 
-    trained_model$coefficients[4]*swrad + 
-    trained_model$coefficients[5]*precip
+    trained_model$coefficients[4]*rh +
+    trained_model$coefficients[5]*swrad + 
+    trained_model$coefficients[6]*precip
   
   return(list(chla = chla))
 }

--- a/3_forecast.R
+++ b/3_forecast.R
@@ -12,12 +12,16 @@ p3_targets_list = list(
   
   tar_target(
     p3_chla_obs_cv,
-    filter(p1_aquatic_targets, siteID == p0_forecast_site_ids,
-           !is.infinite(chla), !is.infinite(chla_sd)) %>% 
-      mutate(chla_cv = (chla_sd / chla)) %>%
-      pull(chla_cv) %>% 
-      median(., na.rm = T),
-    pattern = map(p0_forecast_site_ids)
+    0.05
+    # sd is not stored anymore in the targets file
+    # filter(p1_aquatic_targets, 
+    #        site_id == p0_forecast_site_ids, 
+    #        variable == p0_target_var, 
+    #        !is.infinite(observed), !is.infinite(chla_sd)) %>% 
+    #   mutate(chla_cv = (chla_sd / chla)) %>%
+    #   pull(chla_cv) %>% 
+    #   median(., na.rm = T),
+    # pattern = map(p0_forecast_site_ids)
   ),
   
   tar_target(
@@ -53,8 +57,7 @@ p3_targets_list = list(
                                 p0_forecast_site_ids, 
                                 p1_forecast_issue_date)),
     pattern = map(p0_forecast_site_ids,
-                  p2_train_model,
-                  p3_chla_obs_cv)
+                  p2_train_model)
   ), 
   
   tar_target(

--- a/3_forecast/src/forecast.R
+++ b/3_forecast/src/forecast.R
@@ -246,7 +246,7 @@ forecast = function(trained_model,
                     init_cond_cv = 0.01,
                     site,
                     out_file){
-  
+   
   trained_model = readRDS(trained_model) 
   start = as.Date(start)
   stop = as.Date(stop)

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -12,8 +12,10 @@ p4_targets_list = list(
   tar_target(
     p4_forecast_visual_png,
     visualize_forecast(forecast_file = p3_all_forecasts_csv,
+                       obs = p1_aquatic_targets,
                        out_file = sprintf("4_visualize/out/%s_forecast.png", 
                                           p1_forecast_issue_date))
+    
   )
   
 )

--- a/4_visualize/src/visualize_forecast.R
+++ b/4_visualize/src/visualize_forecast.R
@@ -1,14 +1,21 @@
 
 
 visualize_forecast <- function(forecast_file, 
+                               obs, 
                                out_file){
+   
+  obs <- filter(obs, variable == "chla") %>% 
+    pivot_wider(names_from = variable, values_from = observed) %>% 
+    rename(obs_chla = chla)
   
-  forecasts <- read_csv(forecast_file) 
+  forecasts <- read_csv(forecast_file) %>% 
+    left_join(obs, by = c("time", "site_id"))
   
   plot <- ggplot(data = forecasts) + 
     geom_line(aes(x = time, y = chla, group = ensemble),
               size = 1) + 
-    facet_wrap(~siteID, scale = "free") + 
+    geom_point(aes(x = time, y = obs_chla), color = "red") + 
+    facet_wrap(~site_id, scale = "free") + 
     theme_minimal() + 
     theme(axis.text = element_text(size = 12),
           axis.title = element_text(size = 16), 

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.3",
+    "Version": "4.2.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -23,10 +23,10 @@
     },
     "DBI": {
       "Package": "DBI",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "dcd1743af4336156873e3ce3c950b8b9",
+      "Hash": "b2866e62bab9378c3cc9476a1954226b",
       "Requirements": []
     },
     "EFIstandards": {
@@ -73,22 +73,59 @@
         "stringr"
       ]
     },
-    "MASS": {
-      "Package": "MASS",
-      "Version": "7.3-55",
+    "KernSmooth": {
+      "Package": "KernSmooth",
+      "Version": "2.23-20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c5232ffb549f6d7a04a152c34ca1353d",
+      "Hash": "8dcfa99b14c296bc9f1fd64d52fd3ce7",
+      "Requirements": []
+    },
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-57",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "71476c1d88d1ebdf31580e5a257d5d31",
       "Requirements": []
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.4-0",
+      "Version": "1.4-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "130c0caba175739d98f2963c6a407cf6",
+      "Hash": "699c47c606293bdfbc9fd78a93c9c8fe",
       "Requirements": [
         "lattice"
+      ]
+    },
+    "R.methodsS3": {
+      "Package": "R.methodsS3",
+      "Version": "1.8.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "278c286fd6e9e75d0c2e8f731ea445c8",
+      "Requirements": []
+    },
+    "R.oo": {
+      "Package": "R.oo",
+      "Version": "1.25.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a0900a114f4f0194cf4aa8cd4a700681",
+      "Requirements": [
+        "R.methodsS3"
+      ]
+    },
+    "R.utils": {
+      "Package": "R.utils",
+      "Version": "2.11.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a7ecb8e60815c7a18648e84cd121b23a",
+      "Requirements": [
+        "R.methodsS3",
+        "R.oo"
       ]
     },
     "R6": {
@@ -97,6 +134,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "470851b6d5d0ac559e9d01bb352b4021",
+      "Requirements": []
+    },
+    "RANN": {
+      "Package": "RANN",
+      "Version": "2.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d128ea05a972d3e67c6f39de52c72bd7",
       "Requirements": []
     },
     "RColorBrewer": {
@@ -109,41 +154,49 @@
     },
     "RNetCDF": {
       "Package": "RNetCDF",
-      "Version": "2.5-2",
+      "Version": "2.6-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1d4377a84cdc0cd810d127071339c2b9",
+      "Hash": "5d3141a57c7f7ed20e8ece752173d512",
       "Requirements": []
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.8.3",
+      "Version": "1.0.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "32e79b908fda56ee57fe518a8d37b864",
+      "Hash": "e9c08b94391e9f3f97355841229124f2",
       "Requirements": []
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "0.11.1.1.0",
+      "Version": "0.11.2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "631929e53829901562986c504f86104b",
+      "Hash": "1d3c02a90401734e893954c7f8f92f3e",
       "Requirements": [
         "Rcpp"
       ]
     },
     "V8": {
       "Package": "V8",
-      "Version": "4.2.0",
+      "Version": "4.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0315f0d8f1d2be81b7271a07a0ecc918",
+      "Hash": "2f56b7e2f0d534f3c4022e48c33835ce",
       "Requirements": [
         "Rcpp",
         "curl",
         "jsonlite"
       ]
+    },
+    "abind": {
+      "Package": "abind",
+      "Version": "1.4-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4f57884290cc75ab22f4af9e9d4ca862",
+      "Requirements": []
     },
     "anytime": {
       "Package": "anytime",
@@ -279,10 +332,10 @@
     },
     "broom": {
       "Package": "broom",
-      "Version": "0.8.0",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fe13cb670e14da57fd7a466578db8ce5",
+      "Hash": "c948329889c7b24a4201df3aef5058c2",
       "Requirements": [
         "backports",
         "dplyr",
@@ -299,24 +352,37 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.3.1",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "56ae7e1987b340186a8a5a157c2ec358",
+      "Hash": "be5ee090716ce1671be6cd5d7c34d091",
       "Requirements": [
+        "cachem",
         "htmltools",
         "jquerylib",
         "jsonlite",
+        "memoise",
         "rlang",
         "sass"
       ]
     },
-    "callr": {
-      "Package": "callr",
-      "Version": "3.7.0",
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.0.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "461aa75a11ce2400245190ef5d3995df",
+      "Hash": "648c5b3d71e6a37e3043617489a0a0e9",
+      "Requirements": [
+        "fastmap",
+        "rlang"
+      ]
+    },
+    "callr": {
+      "Package": "callr",
+      "Version": "3.7.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2fda237f24bc56508f31394beaa56877",
       "Requirements": [
         "R6",
         "processx"
@@ -333,12 +399,34 @@
         "tibble"
       ]
     },
-    "cli": {
-      "Package": "cli",
-      "Version": "3.2.0",
+    "class": {
+      "Package": "class",
+      "Version": "7.3-20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1bdb126893e9ce6aae50ad1d6fc32faf",
+      "Hash": "da09d82223e669d270e47ed24ac8686e",
+      "Requirements": [
+        "MASS"
+      ]
+    },
+    "classInt": {
+      "Package": "classInt",
+      "Version": "0.4-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9c04a89713e4c4f9c0f3bf9ef928f852",
+      "Requirements": [
+        "KernSmooth",
+        "class",
+        "e1071"
+      ]
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "3.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "23abf173c2b783dcc43379ab9bba00ee",
       "Requirements": [
         "glue"
       ]
@@ -413,22 +501,38 @@
       "Hash": "36b67b5adf57b292923f5659f5f0c853",
       "Requirements": []
     },
-    "dbplyr": {
-      "Package": "dbplyr",
-      "Version": "2.1.1",
+    "dataRetrieval": {
+      "Package": "dataRetrieval",
+      "Version": "2.7.11",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1f37fa4ab2f5f7eded42f78b9a887182",
+      "Hash": "797d2c2825e960bb44c19549ce0047fe",
+      "Requirements": [
+        "curl",
+        "httr",
+        "jsonlite",
+        "lubridate",
+        "readr",
+        "xml2"
+      ]
+    },
+    "dbplyr": {
+      "Package": "dbplyr",
+      "Version": "2.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f6c7eb9617e4d2a86bb7182fff99c805",
       "Requirements": [
         "DBI",
         "R6",
         "assertthat",
         "blob",
+        "cli",
         "dplyr",
-        "ellipsis",
         "glue",
         "lifecycle",
         "magrittr",
+        "pillar",
         "purrr",
         "rlang",
         "tibble",
@@ -478,10 +582,10 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.0.8",
+      "Version": "1.0.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ef47665e64228a17609d6df877bf86f2",
+      "Hash": "f0bda1627a7f5d3f9a0b5add931596ac",
       "Requirements": [
         "R6",
         "generics",
@@ -512,6 +616,17 @@
         "tibble",
         "tidyselect",
         "vctrs"
+      ]
+    },
+    "e1071": {
+      "Package": "e1071",
+      "Version": "1.7-11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fc02aa712f8600f7da17f44989646a21",
+      "Requirements": [
+        "class",
+        "proxy"
       ]
     },
     "ellipsis": {
@@ -555,10 +670,10 @@
     },
     "farver": {
       "Package": "farver",
-      "Version": "2.1.0",
+      "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c98eb5133d9cb9e1622b8691487f11bb",
+      "Hash": "8106d78941f34855c440ddb946b8f7a5",
       "Requirements": []
     },
     "fastmap": {
@@ -590,6 +705,27 @@
       "Hash": "7c89603d81793f0d5486d91ab1fc6f1d",
       "Requirements": []
     },
+    "fst": {
+      "Package": "fst",
+      "Version": "0.9.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "34637e000c63c3de8d8aafceb82fd082",
+      "Requirements": [
+        "Rcpp",
+        "fstcore"
+      ]
+    },
+    "fstcore": {
+      "Package": "fstcore",
+      "Version": "0.9.12",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1c133b1d853bd4f67043a6e9c17051e2",
+      "Requirements": [
+        "Rcpp"
+      ]
+    },
     "gargle": {
       "Package": "gargle",
       "Version": "1.2.0",
@@ -610,18 +746,18 @@
     },
     "generics": {
       "Package": "generics",
-      "Version": "0.1.2",
+      "Version": "0.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "177475892cf4a55865868527654a7741",
+      "Hash": "15e9634c0fcd294799e9b2e929ed1b86",
       "Requirements": []
     },
     "gert": {
       "Package": "gert",
-      "Version": "1.6.0",
+      "Version": "1.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "98c014c4c933f23ea5a0321a4d0b588b",
+      "Hash": "e8432885a6c629a693c6e0716d1b68ec",
       "Requirements": [
         "askpass",
         "credentials",
@@ -633,10 +769,10 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.3.5",
+      "Version": "3.3.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d7566c471c7b17e095dd023b9ef155ad",
+      "Hash": "0fb26d0674c82705c6b701d1a61e02ea",
       "Requirements": [
         "MASS",
         "digest",
@@ -779,10 +915,10 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.2",
+      "Version": "0.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "526c484233f42522278ab06fb185cb26",
+      "Hash": "6496090a9e00f8354b811d1a2d47b566",
       "Requirements": [
         "base64enc",
         "digest",
@@ -792,10 +928,10 @@
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.2",
+      "Version": "1.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a525aba14184fec243f9eaec62fbed43",
+      "Hash": "88d1b310583777edf01ccd1216fb0b2b",
       "Requirements": [
         "R6",
         "curl",
@@ -817,10 +953,10 @@
     },
     "igraph": {
       "Package": "igraph",
-      "Version": "1.3.0",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bf0f6f80c2eaf5c4485ecbe710dd0a30",
+      "Hash": "48e890b2ccaeb5cdce18f14781ae76d6",
       "Requirements": [
         "Matrix",
         "magrittr",
@@ -841,6 +977,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "7ab57a6de7f48a8dc84910d1eca42883",
+      "Requirements": []
+    },
+    "jpeg": {
+      "Package": "jpeg",
+      "Version": "0.1-9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "441ee36360a57b363f4fa3df0c364630",
       "Requirements": []
     },
     "jqr": {
@@ -886,10 +1030,10 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.38",
+      "Version": "1.39",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "10b3dc3c6acb925910edda5d0543b3a2",
+      "Hash": "029ab7c4badd3cf8af69016b2ba27493",
       "Requirements": [
         "evaluate",
         "highr",
@@ -952,12 +1096,23 @@
       "Hash": "7ce2733a9826b3aeb1775d56fd305472",
       "Requirements": []
     },
-    "mgcv": {
-      "Package": "mgcv",
-      "Version": "1.8-39",
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "055265005c238024e306fe0b600c89ff",
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c",
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ]
+    },
+    "mgcv": {
+      "Package": "mgcv",
+      "Version": "1.8-40",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c6b2fdb18cf68ab613bd564363e1ba0d",
       "Requirements": [
         "Matrix",
         "nlme"
@@ -1030,8 +1185,8 @@
       "RemoteRepo": "neon4cast",
       "RemoteUsername": "eco4cast",
       "RemoteRef": "HEAD",
-      "RemoteSha": "04670ccce1048d5fec0ea693720d80fe30f4f6f5",
-      "Hash": "5bb32a459e6c2a826429bbb7b33b4521",
+      "RemoteSha": "1d528bd573ee723d6a321d2baa8950050c5016e8",
+      "Hash": "40d4a69316e0747157f3582208f3b9d2",
       "Requirements": [
         "EML",
         "ISOweek",
@@ -1051,12 +1206,37 @@
         "yaml"
       ]
     },
-    "nlme": {
-      "Package": "nlme",
-      "Version": "3.1-155",
+    "nhdplusTools": {
+      "Package": "nhdplusTools",
+      "Version": "0.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "74ad940dccc9e977189a5afe5fcdb7ba",
+      "Hash": "c03337a19a80bbd7945b19214f134a4e",
+      "Requirements": [
+        "R.utils",
+        "RANN",
+        "dataRetrieval",
+        "dplyr",
+        "fst",
+        "httr",
+        "jsonlite",
+        "magrittr",
+        "pbapply",
+        "prettymapr",
+        "rosm",
+        "sf",
+        "tidyr",
+        "units",
+        "xml2",
+        "zip"
+      ]
+    },
+    "nlme": {
+      "Package": "nlme",
+      "Version": "3.1-157",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "dbca60742be0c9eddc5205e5c7ca1f44",
       "Requirements": [
         "lattice"
       ]
@@ -1071,24 +1251,30 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.0.0",
+      "Version": "2.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "cf4329aac12c2c44089974559c18e446",
+      "Hash": "6d3bef2e305f55c705c674653c7d7d3d",
       "Requirements": [
         "askpass"
       ]
     },
-    "pillar": {
-      "Package": "pillar",
-      "Version": "1.7.0",
+    "pbapply": {
+      "Package": "pbapply",
+      "Version": "1.5-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "51dfc97e1b7069e9f7e6f83f3589c22e",
+      "Hash": "11359a5bb73622ab3f4136bf57108b64",
+      "Requirements": []
+    },
+    "pillar": {
+      "Package": "pillar",
+      "Version": "1.8.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f95cf85794546c4ac2b9a6ca42e671ff",
       "Requirements": [
         "cli",
-        "crayon",
-        "ellipsis",
         "fansi",
         "glue",
         "lifecycle",
@@ -1105,6 +1291,37 @@
       "Hash": "01f28d4278f15c76cddbea05899c5d6f",
       "Requirements": []
     },
+    "plyr": {
+      "Package": "plyr",
+      "Version": "1.8.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9c17c6ee41639ebdc1d7266546d3b627",
+      "Requirements": [
+        "Rcpp"
+      ]
+    },
+    "png": {
+      "Package": "png",
+      "Version": "0.1-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "03b7076c234cb3331288919983326c55",
+      "Requirements": []
+    },
+    "prettymapr": {
+      "Package": "prettymapr",
+      "Version": "0.2.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2c6a2aec97aec439daecd68d67653868",
+      "Requirements": [
+        "digest",
+        "httr",
+        "plyr",
+        "rjson"
+      ]
+    },
     "prettyunits": {
       "Package": "prettyunits",
       "Version": "1.1.1",
@@ -1115,10 +1332,10 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.5.3",
+      "Version": "3.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8bbae1a548d0d3fdf6647bdd9d35bf6d",
+      "Hash": "f91df0f5f31ffdf88bc0b624f5ebab0f",
       "Requirements": [
         "R6",
         "ps"
@@ -1137,12 +1354,20 @@
         "prettyunits"
       ]
     },
-    "ps": {
-      "Package": "ps",
-      "Version": "1.6.0",
+    "proxy": {
+      "Package": "proxy",
+      "Version": "0.4-27",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "32620e2001c1dce1af49c49dccbb9420",
+      "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e",
+      "Requirements": []
+    },
+    "ps": {
+      "Package": "ps",
+      "Version": "1.7.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8b93531308c01ad0e56d9eadcc0c4fcd",
       "Requirements": []
     },
     "purrr": {
@@ -1166,23 +1391,21 @@
     },
     "read4cast": {
       "Package": "read4cast",
-      "Version": "0.0.0.9000",
+      "Version": "0.0.2",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "read4cast",
       "RemoteUsername": "eco4cast",
       "RemoteRef": "HEAD",
-      "RemoteSha": "66b63159ff4d2a6a30a6cda6c060fe97ad80121b",
-      "Hash": "7dbd35cf3b0281f80fb0d236a62a8e18",
+      "RemoteSha": "223b05de95c7444e965de607186b01b27089c324",
+      "Hash": "3f9907d0ad5070388537fad40f101156",
       "Requirements": [
         "dplyr",
         "lubridate",
         "ncdf4",
         "readr",
-        "tibble",
-        "tidync",
-        "tidyselect"
+        "tidync"
       ]
     },
     "readr": {
@@ -1263,20 +1486,38 @@
         "withr"
       ]
     },
-    "rlang": {
-      "Package": "rlang",
-      "Version": "1.0.2",
+    "rgdal": {
+      "Package": "rgdal",
+      "Version": "1.5-32",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "04884d9a75d778aca22c7154b8333ec9",
+      "Hash": "7e8f18c3a55c90a44ea05e0620c05a7e",
+      "Requirements": [
+        "sp"
+      ]
+    },
+    "rjson": {
+      "Package": "rjson",
+      "Version": "0.2.21",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f9da75e6444e95a1baf8ca24909d63b9",
+      "Requirements": []
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "1.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9103a8f74b2114a5ed1136b471d8feca",
       "Requirements": []
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.13",
+      "Version": "2.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ac78f4d2e0289d4cba73b88af567b8b1",
+      "Hash": "31b60a882fabfabf6785b8599ffeb8ba",
       "Requirements": [
         "bslib",
         "evaluate",
@@ -1288,6 +1529,24 @@
         "tinytex",
         "xfun",
         "yaml"
+      ]
+    },
+    "rosm": {
+      "Package": "rosm",
+      "Version": "0.2.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "28c1e811f574441769c93e5367726c8e",
+      "Requirements": [
+        "abind",
+        "curl",
+        "jpeg",
+        "plyr",
+        "png",
+        "prettymapr",
+        "rgdal",
+        "rjson",
+        "sp"
       ]
     },
     "rprojroot": {
@@ -1322,12 +1581,23 @@
         "xml2"
       ]
     },
-    "sass": {
-      "Package": "sass",
-      "Version": "0.4.1",
+    "s2": {
+      "Package": "s2",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f37c0028d720bab3c513fd65d28c7234",
+      "Hash": "cedf9ef196a446ee8080c14267e69410",
+      "Requirements": [
+        "Rcpp",
+        "wk"
+      ]
+    },
+    "sass": {
+      "Package": "sass",
+      "Version": "0.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1b191143d7d3444d504277843f3a95fe",
       "Requirements": [
         "R6",
         "fs",
@@ -1363,8 +1633,8 @@
       "RemoteRepo": "score4cast",
       "RemoteUsername": "eco4cast",
       "RemoteRef": "HEAD",
-      "RemoteSha": "85aae2ba5964bbb3067be4e3120cb938c2c17b6d",
-      "Hash": "7df9ac0c38e9692154d00fd4388f5ec0",
+      "RemoteSha": "7f6ad3a53beee0b7420fb8736dafbbbe44266df1",
+      "Hash": "eaaa8c7408c87acb567a8a249709457e",
       "Requirements": [
         "ISOweek",
         "arrow",
@@ -1399,12 +1669,37 @@
         "stringr"
       ]
     },
-    "stringi": {
-      "Package": "stringi",
-      "Version": "1.7.6",
+    "sf": {
+      "Package": "sf",
+      "Version": "1.0-7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bba431031d30789535745a9627ac9271",
+      "Hash": "d237b77320537f7793c7a4f83267cf50",
+      "Requirements": [
+        "DBI",
+        "Rcpp",
+        "classInt",
+        "magrittr",
+        "s2",
+        "units"
+      ]
+    },
+    "sp": {
+      "Package": "sp",
+      "Version": "1.5-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "2a118bdd2db0a301711e0a9e3e3206d5",
+      "Requirements": [
+        "lattice"
+      ]
+    },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.7.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a68b980681bcbc84c7a67003fa796bfb",
       "Requirements": []
     },
     "stringr": {
@@ -1429,10 +1724,10 @@
     },
     "tarchetypes": {
       "Package": "tarchetypes",
-      "Version": "0.5.0",
+      "Version": "0.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "69e05d6f7e98f843b1a94266cfd2d2ed",
+      "Hash": "4d76a20b57bc46b0be7ef6ca3cb68e2f",
       "Requirements": [
         "digest",
         "dplyr",
@@ -1447,10 +1742,10 @@
     },
     "targets": {
       "Package": "targets",
-      "Version": "0.11.0",
+      "Version": "0.12.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bcb5125b621b728d8dc23e39f2f07428",
+      "Hash": "e3c201e69f4ca0e4e50fde1cd0aa3137",
       "Requirements": [
         "R6",
         "base64url",
@@ -1471,12 +1766,11 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.6",
+      "Version": "3.1.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8a8f02d1934dfd6431c671361510dd0b",
+      "Hash": "56b6934ef0f8c68225949a8672fe1a8f",
       "Requirements": [
-        "ellipsis",
         "fansi",
         "lifecycle",
         "magrittr",
@@ -1541,10 +1835,10 @@
     },
     "tidyverse": {
       "Package": "tidyverse",
-      "Version": "1.3.1",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fc4c72b6ae9bb283416bd59a3303bbab",
+      "Hash": "972389aea7fa1a34739054a810d0c6f6",
       "Requirements": [
         "broom",
         "cli",
@@ -1579,10 +1873,10 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.38",
+      "Version": "0.40",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "759d047596ac173433985deddf313450",
+      "Hash": "e7b654da5e77bc4e5435a966329cd25f",
       "Requirements": [
         "xfun"
       ]
@@ -1624,6 +1918,16 @@
       "Hash": "b88cada8058e2370a1950ea8407328b4",
       "Requirements": []
     },
+    "units": {
+      "Package": "units",
+      "Version": "0.8-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6c374b265ba437f8d384ec7a313edd96",
+      "Requirements": [
+        "Rcpp"
+      ]
+    },
     "usethis": {
       "Package": "usethis",
       "Version": "2.1.6",
@@ -1662,10 +1966,10 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.0-4",
+      "Version": "1.1-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "99c959c7424be995ddca19b5736c8dd0",
+      "Hash": "f1cb46c157d080b729159d407be83496",
       "Requirements": []
     },
     "vctrs": {
@@ -1727,12 +2031,20 @@
       "Hash": "c0e49a9760983e81e55cdd9be92e7182",
       "Requirements": []
     },
-    "xfun": {
-      "Package": "xfun",
-      "Version": "0.30",
+    "wk": {
+      "Package": "wk",
+      "Version": "0.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e83f48136b041845e50a6658feffb197",
+      "Hash": "d6bc0432436a0aefbf29d5de8588b876",
+      "Requirements": []
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.31",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a318c6f752b8dcfe9fb74d897418ab2b",
       "Requirements": []
     },
     "xml2": {


### PR DESCRIPTION
This updates the download functions and sites to the new NEON forecast challenge sites that still have chl-a sensors. This also adds in some National Water Model download code, but I don't think it's feasible to include in the model as there are many gaps in the data for historic NWM predictions and forecasted NWM availability. historic predictions are available through December 2020 and forecasted data are only available for the last 4 weeks. Additionally, only the short range NWM forecasts are available to the public (18 hours) and we need predictions out to 35 days in the future. 