### PR TITLE
Subdaily info, automate forecast 

### DIFF
--- a/.github/workflows/do_prediction.yml
+++ b/.github/workflows/do_prediction.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
-  #schedule:
-  #- cron: "0 20 * * *"
+  schedule:
+  - cron: "0 20 * * *"
 
 
 jobs:

--- a/1_data.R
+++ b/1_data.R
@@ -16,9 +16,9 @@ p1_targets_list = list(
   tar_target(
     # issue date of the forecast; setting to system time 
     p1_forecast_issue_date, 
-    # as.Date("2022-06-28"),
-    # Sys.Date(),
-    as.Date(Sys.getenv("ISSUE_TIME")), # for testing the model with loop_tar_make.R 
+    # as.Date("2022-09-01"),
+    Sys.Date(), # met forecasts aren't available until the next day 
+    # as.Date(Sys.getenv("ISSUE_TIME")), # for testing the model with loop_tar_make.R 
     cue = tar_cue(mode = "always")
   ),
   
@@ -64,7 +64,8 @@ p1_targets_list = list(
         saveRDS(file = out_file) 
       
       return(out_file) 
-    }
+    },
+    cue = tar_cue("always")
   ),
 
   
@@ -76,14 +77,14 @@ p1_targets_list = list(
                  "AWS_S3_ENDPOINT" = "ecoforecast.org")
 
       out_file = "1_data/out/forecasted_gefs.rds"
-      
+       
       # connect to db 
       forecasted_gefs <- neon4cast::noaa_stage2()
-      
+      date_to_download <- p1_forecast_issue_date - 1
       # filter to sites we want and then pull down to local tibble 
       forecasted_gefs %>% 
         dplyr::filter(site_id %in% p0_forecast_site_ids,
-                      start_date == as.character(p1_forecast_issue_date)) %>% 
+                      start_date == as.character(date_to_download)) %>% 
         dplyr::collect() %>% 
         saveRDS(file = out_file) 
       

--- a/1_data/src/summarize_drivers.R
+++ b/1_data/src/summarize_drivers.R
@@ -9,14 +9,16 @@ summarize_drivers <- function(
 {
    
   data <- readRDS(in_file) 
-   
+  
   if(group_by_ens){
     summarized_data <- data %>% 
       # time offset is about 5 hours  
       mutate(time = time - (5 * 3600),
              time = as_date(time)) %>% 
       group_by(site_id, time, ensemble, variable) %>% 
-      summarise(predicted = mean(predicted, na.rm = T), 
+      summarise(predicted_mean = mean(predicted, na.rm = T), 
+                predicted_max = max(predicted, na.rm = T), 
+                predicted_min = min(predicted, na.rm = T), 
                 .groups = "drop") 
   }else{
     summarized_data <- data %>% 
@@ -24,7 +26,9 @@ summarize_drivers <- function(
       mutate(time = time - (5 * 3600),
              time = as_date(time)) %>% 
       group_by(site_id, time, variable) %>% 
-      summarise(predicted = mean(predicted, na.rm = T), 
+      summarise(predicted_mean = mean(predicted, na.rm = T), 
+                predicted_max = max(predicted, na.rm = T), 
+                predicted_min = min(predicted, na.rm = T), 
                 .groups = "drop") 
   }
   

--- a/2_model.R
+++ b/2_model.R
@@ -13,7 +13,7 @@ p2_targets_list = list(
   tar_target(
     # model to train and use for forecast 
     p2_model_type,
-    "linear"
+    "random_forest"
   ),
   
   tar_target(

--- a/3_forecast.R
+++ b/3_forecast.R
@@ -27,7 +27,7 @@ p3_targets_list = list(
   
   tar_target(
     p3_start_forecast, 
-    p1_forecast_issue_date - 5
+    p1_forecast_issue_date - 10
   ),
   
   tar_target(
@@ -71,7 +71,6 @@ p3_targets_list = list(
     # combine forecasts from all sites 
     p3_all_forecasts_csv,
     {
-      why = 1
       out_file <- paste0("3_forecast/out/aquatics", "-", 
                          p1_forecast_issue_date ,"-", 
                          p0_team_name, ".csv")

--- a/4_visualize/src/visualize_forecast.R
+++ b/4_visualize/src/visualize_forecast.R
@@ -3,32 +3,32 @@
 visualize_forecast <- function(forecast_file, 
                                obs, 
                                out_file){
-   
+  
   obs <- filter(obs, 
-                variable == "chla") %>% 
-    pivot_wider(names_from = variable, values_from = observed) %>% 
-    rename(obs_chla = chla)
+                variable == "chla") # %>% 
+    # pivot_wider(names_from = variable, values_from = observed) %>% 
+    # rename(obs_chla = chla)
   
   forecasts <- read_csv(forecast_file) %>% 
-    left_join(obs, by = c("time", "site_id"))
+    left_join(obs, by = c("time", "site_id", "variable")) %>% as_tibble()
   
   obs <- filter(obs, time >= min(forecasts$time), 
-                time <= max(forecasts$time))
+                time <= max(forecasts$time)) %>% as_tibble()
   
   show_all_predicted = TRUE 
   
   # Breaks by 5, then associated with the data for dynamic coloring of text/ticks
   breaks_all <- seq(0,100, by = 5)
-  breaks_draw <- breaks_all[breaks_all >= min(forecasts$chla, na.rm = T)]
+  breaks_draw <- breaks_all[breaks_all >= min(forecasts$predicted, na.rm = T)]
   # forecast plot code copied from
   #  https://github.com/USGS-VIZLAB/forecast-drb/blob/bf40ad748814298878c76eaa793cd1e68e2f62a4/3_visualize/src/plot_interval.R
-  browser() 
+   
   # plot 1-day out predictions with mean prediction
   plot <- forecasts %>%
     ggplot(
       aes(
         x = time,
-        y = chla,
+        y = predicted,
         group = site_id
       )) +
     labs(x = " ",
@@ -91,7 +91,7 @@ visualize_forecast <- function(forecast_file,
           panel.spacing = unit(0,"lines"))+
     scale_x_date(breaks = scales::breaks_width("5 day"),
                  labels = scales::label_date_short()) + 
-    geom_point(data = obs, aes(x = time, y = obs_chla), color = "red") 
+    geom_point(data = obs, aes(x = time, y = observed), color = "red") 
 
 
   ggsave(filename = out_file, plot = plot, bg = "white", 

--- a/5_metadata.R
+++ b/5_metadata.R
@@ -11,10 +11,35 @@ tar_option_set(packages = c(
 p5_targets_list = list(
   
   tar_target(
+    p5_forecast_model_id,
+    "rf_met_drivers"
+  ),
+  
+  tar_target(
+    p5_n_model_drivers,
+    {
+      model = read_rds(p2_train_model[1])
+      return(nrow(model$importance))
+    }
+  ),
+  
+  tar_target(
+    p5_n_model_parameters,
+    {
+      model = read_rds(p2_train_model)
+      # find number of feature splits. this is analogous to number of parameters
+      feature_splits = randomForest::treesize(model, terminal = F) - randomForest::treesize(model, terminal = T)
+      return(floor(median(feature_splits)))
+    },
+    pattern = map(p2_train_model)
+  ),
+  
+  tar_target(
     p5_metadata_to_submit_xml,
     neon4cast::generate_metadata(forecast_file = p3_all_forecasts_csv,
                                  team_list = p0_team_list,
-                                 model_metadata =  p5_model_metadata)
+                                 model_metadata =  p5_model_metadata,
+                                 forecast_issue_time = p1_forecast_issue_date),
   ),
   
   tar_target(
@@ -22,35 +47,64 @@ p5_targets_list = list(
     list(
       forecast = list(
         model_description = list(
-          forecast_model_id =  "air2waterSat",  
-          name = "Linear regression of air temperature and precipitation to chl-a", 
-          type = "empirical",  
-          repository = "https://github.com/USGS-R/habs-proxies-forecast-chl" 
+          forecast_model_id = p5_forecast_model_id, # model identifier:
+          name = "Random Forest regression of meteorological drivers to predict chl-a", #Name or short description of model
+          type = "machine learning", #General type of model empirical, machine learning, process
+          repository = "https://github.com/USGS-R/habs-proxies-forecast-chl" # put your GitHub Repository in here
         ),
         initial_conditions = list(
-          status = "absent"
+          status = "assimilates", #options: absent, present, data_driven, propagates, assimilates
+          complexity = 1, #How many models states need initial conditions; delete if status = absent
+          #Delete list below if status = absent, present, or data_driven
+          propagation = list(
+            type = "ensemble", #How does your model propogate initial conditions ('ensemble' is most common)
+            size = 3100 #number of ensemble members
+          ),
+          #Delete list below UNLESS status = assimilates
+          assimilation = list(
+            type = "EnKF", #description of assimilation method
+            reference = "Zwart et al. 2021 doi.org/10.31223/X55K7G", #reference for assimilation method
+            complexity = 1 #number of states that are updated with assimilation
+          )
         ),
         drivers = list(
-          status = "propagates",
-          complexity = 3, 
-          propagation = list( 
-            type = "ensemble", 
-            size = p3_n_en) 
+          status = "propagates", #options: absent, present, data_driven, propagates, assimilates
+          complexity = p5_n_model_drivers, #How many drivers are used? Delete if status = absent
+          #Delete list below if status = absent, present, or data_driven
+          propagation = list(
+            type = "ensemble", #How does your model propogate driver (ensemble or MCMC is most common
+            size = 31 #number of ensemble or MCMC members
+          )
         ),
         parameters = list(
-          status = "absent"
+          status = "data_driven", #options: absent, present, data_driven, propagates, assimilates
+          complexity = floor(mean(p5_n_model_parameters)) #How many parameters are included?; Delete if status = absent
         ),
         random_effects = list(
-          status = "absent"
+          status = "absent" #options: absent, present, data_driven, propagates, assimilates
         ),
         process_error = list(
-          status = "absent"
+          status = "assimilates", #options: absent, present, data_driven, propagates, assimilates
+          complexity = 1, #Delete if status = absent
+          #Delete the list below below blank if status = absent, present, or data_driven
+          propagation = list(
+            type = "ensemble", #How does your model propagate random effects uncertainty (ensemble or MCMC is most common)
+            size = 3100 #How many ensemble or MCMC members
+          ),
+          #Delete the list below UNLESS status = assimilates
+          assimilation = list(
+            type = "EnKF", #Name of data assilimilation method
+            reference = "Zwart et al. 2021 doi.org/10.31223/X55K7G", #Reference for data assimilation method
+            complexity = 1, #Number of states assimilate
+            covariance = TRUE, #TRUE OR FALSE
+            localization = FALSE #TRUE OR FALSE
+          )
         ),
         obs_error = list(
-          status = "absent"
+          status = "data_driven", #options: absent, present, data_driven, propagates, assimilates
+          complexity = 1 #Delete if status = absent
         )
       )
     )
   )
-  
 )

--- a/6_submit.R
+++ b/6_submit.R
@@ -14,10 +14,9 @@ p6_targets_list = list(
       Sys.setenv("AWS_DEFAULT_REGION" = "data",
                  "AWS_S3_ENDPOINT" = "ecoforecast.org")
       
-      # UNCOMMENT THIS WHEN WE'RE READY TO SUBMIT THE FORECASTS 
-      # neon4cast::submit(forecast_file = p3_all_forecasts_csv, 
-      #                   metadata = p5_metadata_to_submit_xml, 
-      #                   ask = FALSE)
+      neon4cast::submit(forecast_file = p3_all_forecasts_csv,
+                        metadata = p5_metadata_to_submit_xml,
+                        ask = FALSE)
     }
   )
   

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NOTE: A lot of the details on standardized environment and automation come from 
 ### Ready to submit a forecast automatically?
 
 1) Uncomment the `p6_submit` target. 
-2) Uncomment the `schedule:` and `- cron: "0 20 * * *"` lines in the `.github/workflow/do_prediction.yml` file. This cron job will run the forecast in this repository daily at 20:00 UTC, and the execution of the forecast occurs on GitHub's servers, so your local computer does not need to be turned on. You can update this to run on a different schedule based on timing codes found in https://crontab.guru
+2) Uncomment the `schedule:` and `- cron: "0 20 * * *"` lines in the `.github/workflows/do_prediction.yml` file. This cron job will run the forecast in this repository daily at 20:00 UTC, and the execution of the forecast occurs on GitHub's servers, so your local computer does not need to be turned on. You can update this to run on a different schedule based on timing codes found in https://crontab.guru
 3) Commit and push the changes to Github. 
 
 ### Running the pipeline in GitHub actions manually 

--- a/loop_tar_make.R
+++ b/loop_tar_make.R
@@ -1,6 +1,6 @@
 library(targets)
 
-issue_dates <- as.character(seq(from = as.Date('2022-06-30'),
+issue_dates <- as.character(seq(from = as.Date('2022-05-01'),
                                 to = as.Date('2022-08-20'),
                                 by = 'day'))
 

--- a/renv.lock
+++ b/renv.lock
@@ -59,6 +59,14 @@
         "xml2"
       ]
     },
+    "HDInterval": {
+      "Package": "HDInterval",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3b986a53325a1d95610b8d86a284dac0",
+      "Requirements": []
+    },
     "ISOweek": {
       "Package": "ISOweek",
       "Version": "0.6-2",
@@ -763,6 +771,27 @@
         "zip"
       ]
     },
+    "ggdist": {
+      "Package": "ggdist",
+      "Version": "3.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "da5ae53a708eb6f8d2f9ec6acd188fd9",
+      "Requirements": [
+        "HDInterval",
+        "distributional",
+        "dplyr",
+        "ggplot2",
+        "glue",
+        "numDeriv",
+        "rlang",
+        "scales",
+        "tibble",
+        "tidyselect",
+        "vctrs",
+        "withr"
+      ]
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.3.6",
@@ -1181,8 +1210,8 @@
       "RemoteRepo": "neon4cast",
       "RemoteUsername": "eco4cast",
       "RemoteRef": "HEAD",
-      "RemoteSha": "1d528bd573ee723d6a321d2baa8950050c5016e8",
-      "Hash": "40d4a69316e0747157f3582208f3b9d2",
+      "RemoteSha": "628da6d62fb3c04ba38933946c97a65757657ace",
+      "Hash": "37f89b677473f69a6ce8ff53da7b190d",
       "Requirements": [
         "EML",
         "ISOweek",
@@ -1244,6 +1273,26 @@
       "Repository": "CRAN",
       "Hash": "df58958f293b166e4ab885ebcad90e02",
       "Requirements": []
+    },
+    "nwmTools": {
+      "Package": "nwmTools",
+      "Version": "0.0.1",
+      "Source": "GitHub",
+      "Remotes": "mikejohnson51/AOI",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "nwmTools",
+      "RemoteUsername": "mikejohnson51",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "ae2247d5daef00d0ea2d7adba881804b95225576",
+      "Hash": "92fcb0f148187482e36e037b63db4bfc",
+      "Requirements": [
+        "RNetCDF",
+        "dplyr",
+        "httr",
+        "lubridate",
+        "sys"
+      ]
     },
     "openssl": {
       "Package": "openssl",
@@ -1376,6 +1425,14 @@
         "magrittr",
         "rlang"
       ]
+    },
+    "randomForest": {
+      "Package": "randomForest",
+      "Version": "4.7-1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b52825075358b1ebd159e262bf40649d",
+      "Requirements": []
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -1617,6 +1674,16 @@
         "munsell",
         "rlang",
         "viridisLite"
+      ]
+    },
+    "scico": {
+      "Package": "scico",
+      "Version": "1.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4475e7ab0908ca91855f78baf2e9137e",
+      "Requirements": [
+        "scales"
       ]
     },
     "score4cast": {


### PR DESCRIPTION
This PR adds in subdaily meteorological information to the model training and forecasting, summarizing the GEFS to min, mean, max values for each variable. Model performance was slightly improved compared to models without subdaily information. 

Also automating the forecasts submissions by uncommenting the `p6_submit` target and setting the cron schedule for 20:00 UTC. 

